### PR TITLE
Add --fusecmd option

### DIFF
--- a/cmd/internal/cli/action_flags.go
+++ b/cmd/internal/cli/action_flags.go
@@ -29,6 +29,7 @@ var (
 	VMRAM           string
 	VMCPU           string
 	ContainLibsPath []string
+	FuseCmd         []string
 
 	IsBoot          bool
 	IsFakeroot      bool
@@ -257,6 +258,17 @@ var actionContainLibsFlag = cmdline.Flag{
 	Name:         "containlibs",
 	Hidden:       true,
 	EnvKeys:      []string{"CONTAINLIBS"},
+	ExcludedOS:   []string{cmdline.Darwin},
+}
+
+// --fusecmd
+var actionFuseCmdFlag = cmdline.Flag{
+	ID:           "actionFuseCmdFlag",
+	Value:        &FuseCmd,
+	DefaultValue: []string{},
+	Name:         "fusecmd",
+	Usage:        "Command to run inside the container to implement a libfuse3-based filesystem. The last parameter is a mountpoint that will be pre-mounted and replaced with a /dev/fd/NN path to the fuse file descriptor.",
+	EnvKeys:      []string{"FUSECMD"},
 	ExcludedOS:   []string{cmdline.Darwin},
 }
 
@@ -621,6 +633,7 @@ func init() {
 	cmdManager.RegisterFlagForCmd(&actionVMRAMFlag, actionsCmd...)
 	cmdManager.RegisterFlagForCmd(&actionVMCPUFlag, actionsCmd...)
 	cmdManager.RegisterFlagForCmd(&actionContainLibsFlag, actionsInstanceCmd...)
+	cmdManager.RegisterFlagForCmd(&actionFuseCmdFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionDockerUsernameFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionDockerPasswordFlag, actionsInstanceCmd...)
 	cmdManager.RegisterFlagForCmd(&actionTmpDirFlag, actionsCmd...)

--- a/cmd/internal/cli/actions_linux.go
+++ b/cmd/internal/cli/actions_linux.go
@@ -231,6 +231,7 @@ func execStarter(cobraCmd *cobra.Command, image string, args []string, name stri
 	}
 
 	engineConfig.SetBindPath(BindPaths)
+	engineConfig.SetFuseCmd(FuseCmd)
 	engineConfig.SetNetwork(Network)
 	engineConfig.SetDNS(DNS)
 	engineConfig.SetNetworkArgs(NetworkArgs)

--- a/internal/pkg/runtime/engines/config/config.go
+++ b/internal/pkg/runtime/engines/config/config.go
@@ -8,10 +8,9 @@ package config
 // Common provides the basis for all engine configs. Anything that can not be
 // properly described through the OCI config can be stored as generic JSON []byte
 type Common struct {
-	EngineName  string `json:"engineName"`
-	ContainerID string `json:"containerID"`
-	// EngineConfig is the raw JSON representation of the Engine's underlying config
-	EngineConfig EngineConfig `json:"engineConfig"`
+	EngineName   string       `json:"engineName"`
+	ContainerID  string       `json:"containerID"`
+	EngineConfig EngineConfig `json:"engineConfig"` // EngineConfig is the raw JSON representation of the Engine's underlying config
 }
 
 // EngineConfig is a generic interface to represent the implementations of an EngineConfig

--- a/internal/pkg/runtime/engines/singularity/prepare_linux.go
+++ b/internal/pkg/runtime/engines/singularity/prepare_linux.go
@@ -720,6 +720,42 @@ func (e *EngineOperations) PrepareConfig(starterConfig *starter.Config) error {
 		starterConfig.SetCapabilities(capabilities.Ambient, e.EngineConfig.OciConfig.Process.Capabilities.Ambient)
 	}
 
+	// We must call this here because at this point we haven't
+	// spawned the master process nor the RPC server. The assumption
+	// is that this function runs in stage 1 and that even if it's a
+	// separate process, it's created in such a way that it's
+	// sharing its file descriptor table with the wrapper / stage 2.
+	//
+	// At this point we do not have elevated privileges. We assume
+	// that the user running singularity has access to /dev/fuse
+	// (typically it's 0666, or 0660 belonging to a group that
+	// allows the user to read and write to it).
+	if err := openDevFuse(e, starterConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// openDevFuse is a helper function that opens /dev/fuse once for each
+// plugin that wants to mount a FUSE filesystem.
+func openDevFuse(e *EngineOperations, starterConfig *starter.Config) error {
+	for _, name := range e.EngineConfig.GetPluginFuseMounts() {
+		fd, err := syscall.Open("/dev/fuse", syscall.O_RDWR, 0)
+		if err != nil {
+			sylog.Debugf("Calling open: %+v\n", err)
+			return err
+		}
+
+		err = e.EngineConfig.SetPluginFuseFd(name, fd)
+		if err != nil {
+			sylog.Debugf("Unable to setup plugin %s fd: %+v\n", name, err)
+			return err
+		}
+
+		starterConfig.KeepFileDescriptor(fd)
+	}
+
 	return nil
 }
 

--- a/internal/pkg/runtime/engines/singularity/process_linux.go
+++ b/internal/pkg/runtime/engines/singularity/process_linux.go
@@ -9,6 +9,7 @@ import (
 	"debug/elf"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -146,8 +147,106 @@ func (engine *EngineOperations) checkExec() error {
 	return fmt.Errorf("no %s found inside container", args[0])
 }
 
+func runFuseDriver(name string, program []string, fd int) error {
+	sylog.Debugf("Running FUSE driver for %s as %v, fd %d", name, program, fd)
+
+	fh := os.NewFile(uintptr(fd), "fd-"+name)
+	if fh == nil {
+		// this should never happen
+		return errors.New("cannot map /dev/fuse file descriptor to a file handle")
+	}
+	// the master process does not need this file descriptor after
+	// running the program, make sure it gets closed; ignore any
+	// errors that happen here
+	defer fh.Close()
+
+	// The assumption is that the plugin prepared "Program" in such
+	// a way that it's missing the last parameter and that must
+	// correspond to /dev/fd/N. Instead of making assumptions as to
+	// how many and which file descriptors are open at this point,
+	// simply assume that it's possible to map the existing file
+	// descriptor to the name number in the new process.
+	//
+	// "newFd" should be the same as "fd", but do not assume that
+	// either.
+	newFd := fh.Fd()
+	fdDevice := fmt.Sprintf("/dev/fd/%d", newFd)
+	args := append(program, fdDevice)
+	sylog.Debugf("args=%v", args)
+	cmd := exec.Command(args[0], args[1:]...)
+
+	// Add the /dev/fuse file descriptor to the list of file
+	// descriptors to be passed to the new process.
+	//
+	// ExtraFiles is an array of *os.File, with the position of each
+	// entry determining the resulting file descriptor number. Since
+	// we are passing /dev/fd/N above, place our file handle at
+	// position N-3, so that it gets mapped to file descriptor N in
+	// the new process (the Go library will set things up so that
+	// stdin, stdout and stderr are 0, 1, and 2, so the first
+	// element of ExtraFiles gets 3).
+	cmd.ExtraFiles = make([]*os.File, newFd-3+1)
+	cmd.ExtraFiles[newFd-3] = fh
+	// The FUSE driver will get SIGQUIT if the parent dies.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGQUIT,
+	}
+
+	if err := cmd.Start(); err != nil {
+		sylog.Debugf("cannot start program %v: %v\n", args, err)
+		return err
+	}
+
+	return nil
+}
+
+// setupFuseDrivers runs the operations required by FUSE drivers before
+// the user process starts
+func setupFuseDrivers(engine *EngineOperations) error {
+	// close file descriptors open for FUSE mount
+	for _, name := range engine.EngineConfig.GetPluginFuseMounts() {
+		var cfg struct {
+			Fuse struct {
+				DevFuseFd int
+				Program   []string
+			}
+		}
+		if err := engine.EngineConfig.GetPluginConfig(name, &cfg); err != nil {
+			return err
+		}
+
+		if err := runFuseDriver(name, cfg.Fuse.Program, cfg.Fuse.DevFuseFd); err != nil {
+			return err
+		}
+
+		syscall.Close(cfg.Fuse.DevFuseFd)
+	}
+
+	return nil
+}
+
+// preStartProcess does the final set up before starting the user's
+// process.
+func preStartProcess(engine *EngineOperations) error {
+	// TODO(mem): most of the StartProcess method should be here, as
+	// it's doing preparation for actually starting the user
+	// process.
+	//
+	// For now it's limited to doing the final set up for FUSE
+	// drivers
+	if err := setupFuseDrivers(engine); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // StartProcess starts the process
 func (engine *EngineOperations) StartProcess(masterConn net.Conn) error {
+	if err := preStartProcess(engine); err != nil {
+		return err
+	}
+
 	isInstance := engine.EngineConfig.GetInstance()
 	bootInstance := isInstance && engine.EngineConfig.GetBootInstance()
 	shimProcess := false

--- a/internal/pkg/util/fs/mount/mount_linux.go
+++ b/internal/pkg/util/fs/mount/mount_linux.go
@@ -154,6 +154,7 @@ var authorizedFS = map[string]fsContext{
 	"proc":    {false},
 	"mqueue":  {false},
 	"cgroup":  {false},
+	"fuse":    {false},
 }
 
 var internalOptions = []string{"loop", "offset", "sizelimit"}

--- a/pkg/runtime/engines/singularity/config/config.go
+++ b/pkg/runtime/engines/singularity/config/config.go
@@ -6,7 +6,6 @@
 package singularity
 
 import (
-	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/oci"
 	"github.com/sylabs/singularity/pkg/image"
 )
 
@@ -91,17 +90,6 @@ type JSONConfig struct {
 	TargetUID     int           `json:"targetUID,omitempty"`
 	TargetGID     []int         `json:"targetGID,omitempty"`
 	LibrariesPath []string      `json:"librariesPath,omitempty"`
-}
-
-// NewConfig returns singularity.EngineConfig with a parsed FileConfig
-func NewConfig() *EngineConfig {
-	ret := &EngineConfig{
-		JSON:      &JSONConfig{},
-		OciConfig: &oci.Config{},
-		File:      &FileConfig{},
-	}
-
-	return ret
 }
 
 // SetImage sets the container image path to be used by EngineConfig.JSON.

--- a/pkg/runtime/engines/singularity/config/config_linux.go
+++ b/pkg/runtime/engines/singularity/config/config_linux.go
@@ -6,6 +6,9 @@
 package singularity
 
 import (
+	"encoding/json"
+	"errors"
+
 	"github.com/sylabs/singularity/internal/pkg/cgroups"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/oci"
 	"github.com/sylabs/singularity/pkg/network"
@@ -13,9 +16,117 @@ import (
 
 // EngineConfig stores both the JSONConfig and the FileConfig
 type EngineConfig struct {
-	JSON      *JSONConfig      `json:"jsonConfig"`
-	OciConfig *oci.Config      `json:"ociConfig"`
-	File      *FileConfig      `json:"-"`
-	Network   *network.Setup   `json:"-"`
-	Cgroups   *cgroups.Manager `json:"-"`
+	JSON      *JSONConfig                `json:"jsonConfig"`
+	OciConfig *oci.Config                `json:"ociConfig"`
+	File      *FileConfig                `json:"-"`
+	Network   *network.Setup             `json:"-"`
+	Cgroups   *cgroups.Manager           `json:"-"`
+	Plugin    map[string]json.RawMessage `json:"plugin"` // Plugin is the raw JSON representation of the plugin configurations
+}
+
+// NewConfig returns singularity.EngineConfig with a parsed FileConfig
+func NewConfig() *EngineConfig {
+	ret := &EngineConfig{
+		JSON:      &JSONConfig{},
+		OciConfig: &oci.Config{},
+		File:      &FileConfig{},
+		Plugin:    make(map[string]json.RawMessage),
+	}
+
+	return ret
+}
+
+// GetPluginConfig retrieves the configuration for the named plugin
+func (e *EngineConfig) GetPluginConfig(plugin string, cfg interface{}) error {
+	if tmp, found := e.Plugin[plugin]; found {
+		return json.Unmarshal(tmp, cfg)
+	}
+
+	return nil
+}
+
+// SetPluginConfig sets the configuration for the named plugin
+func (e *EngineConfig) SetPluginConfig(plugin string, cfg interface{}) error {
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	e.Plugin[plugin] = json.RawMessage(data)
+	return nil
+}
+
+// GetPluginFuseMounts returns the list of plugins which have a valid
+// FUSE configuration.
+//
+// In this context "valid" means that both the mount point and the FUSE
+// driver program exist in the configuration. This function DOES NOT
+// check if the /dev/fuse file descriptor has been assigned.
+func (e *EngineConfig) GetPluginFuseMounts() []string {
+	var list []string
+
+	for name, raw := range e.Plugin {
+		var info struct {
+			Fuse struct {
+				DevFuseFd  int
+				MountPoint string
+				Program    []string
+			}
+		}
+		if err := json.Unmarshal(raw, &info); err != nil {
+			// do not log anything because this would
+			// introduce a lot of noise into the log, even
+			// for the debug level
+			continue
+		}
+		if len(info.Fuse.Program) > 0 && info.Fuse.MountPoint != "" {
+			// This a valid configuration
+			list = append(list, name)
+		}
+	}
+
+	return list
+}
+
+// SetPluginFuseFd sets the /dev/fuse file descriptor fd for the
+// specified plugin
+//
+// This function tries to make sure that any additional configuration
+// already found in the "Fuse" object is preserved.
+func (e *EngineConfig) SetPluginFuseFd(name string, fd int) error {
+	raw, found := e.Plugin[name]
+	if !found {
+		// named plugin does not have a configuration
+		// entry, error out
+		return errors.New("plugin not found")
+	}
+
+	var obj map[string]interface{}
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		// cannot unmarshal value as JSON, error out
+		return errors.New("invalid JSON entry")
+	}
+
+	tmp, found := obj["Fuse"]
+	if !found {
+		// object does not have a Fuse key, error out
+		return errors.New("missing Fuse JSON object")
+	}
+
+	info, ok := tmp.(map[string]interface{})
+	if !ok {
+		// invalid value, error out
+		return errors.New("invalid Fuse JSON object")
+	}
+
+	info["DevFuseFd"] = fd
+	obj["Fuse"] = info
+	newval, err := json.Marshal(obj)
+	if err != nil {
+		// this should not happen
+		return errors.New("cannot marshal new JSON object")
+	}
+
+	e.Plugin[name] = json.RawMessage(newval)
+
+	return nil
 }

--- a/pkg/runtime/engines/singularity/config/config_linux.go
+++ b/pkg/runtime/engines/singularity/config/config_linux.go
@@ -8,9 +8,13 @@ package singularity
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/sylabs/singularity/internal/pkg/cgroups"
 	"github.com/sylabs/singularity/internal/pkg/runtime/engines/config/oci"
+	"github.com/sylabs/singularity/internal/pkg/sylog"
 	"github.com/sylabs/singularity/pkg/network"
 )
 
@@ -52,6 +56,50 @@ func (e *EngineConfig) SetPluginConfig(plugin string, cfg interface{}) error {
 		return err
 	}
 	e.Plugin[plugin] = json.RawMessage(data)
+	return nil
+}
+
+//SetFuseCmd takes input from --fusecmd flags and creates plugin objects from them to hook in to the fuse plugin support code
+func (e *EngineConfig) SetFuseCmd(fusecmd []string) error {
+	for _, cmd := range fusecmd {
+		//Splits the command into a list of whitespace-separated words
+		words := strings.Fields(cmd)
+		if len(words) == 1 {
+			sylog.Fatalf("No whitespace separators found in command")
+		}
+
+		//The last word in the list is the mount point
+		mnt := words[len(words)-1]
+
+		//The mount point must be a directory
+		if !strings.HasPrefix(mnt, "/") {
+			sylog.Fatalf("Invalid mount point %s.\n", mnt)
+		}
+
+		//Removes the mount point from the list of words
+		words = words[0 : len(words)-1]
+
+		sylog.Verbosef("Mounting FUSE filesystem with %s %s\n",
+			strings.Join(words, " "), mnt)
+
+		//Creates a fuse plugin config struct
+		var cfg struct {
+			Fuse struct {
+				DevFuseFd  int
+				MountPoint string
+				Program    []string
+			}
+		}
+
+		//Adds the mount point and program to the fuse plugin config struct
+		cfg.Fuse.MountPoint = mnt
+		cfg.Fuse.Program = words
+
+		//Runs SetPluginConfig to create a plugin object
+		if err := e.SetPluginConfig(mnt, cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "Cannot set plugin configuration: %+v\n", err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/runtime/engines/singularity/config/config_unsupported.go
+++ b/pkg/runtime/engines/singularity/config/config_unsupported.go
@@ -17,3 +17,14 @@ type EngineConfig struct {
 	OciConfig *oci.Config `json:"ociConfig"`
 	File      *FileConfig `json:"-"`
 }
+
+// NewConfig returns singularity.EngineConfig with a parsed FileConfig
+func NewConfig() *EngineConfig {
+	ret := &EngineConfig{
+		JSON:      &JSONConfig{},
+		OciConfig: &oci.Config{},
+		File:      &FileConfig{},
+	}
+
+	return ret
+}


### PR DESCRIPTION
**Description of the Pull Request (PR):**

This adds the --fusecmd option which mounts a fuse mountpoint that is implemented by the command inside the container.  This implementation is the simplest, based on existing plugin functionality for fuse mounts.  An alternative would be to rewrite the fuse mount plugin functionality to have lower level hooks that would be more appropriate for this option.

**This fixes or addresses the following GitHub issues:**

- None in the mem repository


**Before submitting a PR, make sure you have done the following:**

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @mem @DrDaveD
